### PR TITLE
RabbitMQ 

### DIFF
--- a/auth_service/main.py
+++ b/auth_service/main.py
@@ -1,14 +1,20 @@
 import sys
 sys.path.append('/app')
 from fastapi import FastAPI
-
-from config import settings
 from routers.auth import router as auth_router
 from routers.users import router as users_router
-from database import get_db
 
 
-app = FastAPI(title=settings.APP_NAME, debug=settings.DEBUG)
+
+app = FastAPI(
+    title="AuthService API",
+    version="1.0.0",
+    openapi_url="/openapi.json",
+    docs_url="/docs",
+    redoc_url="/redoc",
+    root_path="",
+    root_path_in_servers=True
+)
 
 # Подключаем маршруты для авторизации
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,28 +1,28 @@
-version: '3.8'
+version: "3.8"
 
 services:
-
   rabbitmq:
     image: rabbitmq:3-management
     ports:
-      - "5672:5672"
-      - "15672:15672" # Веб-интерфейс управления RabbitMQ
+      - "5672:5672"      # для приложений (FastStream, pika и т.п.)
+      - "15672:15672"    # веб-интерфейс RabbitMQ
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
 
   posts_service:
     build:
       context: ./posts_service
-      dockerfile: Dockerfile
+      dockerfile: ./Dockerfile
     container_name: posts_service
     ports:
       - "8000:8000"
     environment:
-      DB_HOST: Posts_service_db # name of container
+      DB_HOST: Posts_service_db
       DB_PORT: 5432
-      DB_NAME: posts_db # name of DB in pgAdmin
+      DB_NAME: posts_db
       DB_USER: postgres
       DB_PASSWORD: postgres
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
     volumes:
       - ./posts_service:/app
     depends_on:
@@ -55,10 +55,12 @@ services:
       DB_USER: postgres
       DB_PASSWORD: postgres
       PYTHONPATH: /app
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
     volumes:
       - ./auth_service:/app
     depends_on:
       - auth_db
+      - rabbitmq
 
   auth_db:
     image: postgres:15.3
@@ -75,48 +77,34 @@ services:
   subscription_service:
     build:
       context: ./subscription_service
-      dockerfile: Dockerfile
+      dockerfile: ./Dockerfile
     container_name: subscription_service
     ports:
       - "8004:8004"
     environment:
-      DB_HOST: subscription_db
+      DB_HOST: subscription_service_db
       DB_PORT: 5432
-      DB_NAME: subscribe_db
+      DB_NAME: subscription_db
       DB_USER: postgres
       DB_PASSWORD: postgres
-      PYTHONPATH: /app
-    working_dir: /app
+      RABBITMQ_URL: amqp://guest:guest@rabbitmq:5672/
     volumes:
       - ./subscription_service:/app
     depends_on:
       - rabbitmq
       - subscription_db
-    command: uvicorn main:app --host 0.0.0.0 --port 8004 --reload
 
   subscription_db:
     image: postgres:15.3
     container_name: subscription_service_db
     environment:
-      POSTGRES_DB: subscribe_db
+      POSTGRES_DB: subscription_db
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     ports:
       - "5434:5432"
     volumes:
       - subscription_db_data:/var/lib/postgresql/data
-
-#  nginx:
-#    image: nginx:latest
-#    container_name: nginx
-#    ports:
-#      - "80:80"
-#    volumes:
-#      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-#    depends_on:
-#      - auth_service
-#      - lostfound_service
-#      - auction_service
 
 volumes:
   posts_db_data:


### PR DESCRIPTION
docker-compose.yml:Настроены переменные окружения для подключения к R…abbitMQ (RABBITMQ_URL) для всех сервисов (auth_service, posts_service, subscription_service).

- Указаны порты для RabbitMQ (5672 для AMQP и 15672 для веб-интерфейса управления) main.py/auth_service:Настроены параметры FastAPI для документации OpenAPI (openapi_url, docs_url, redoc_url).